### PR TITLE
ReadonlyMoveCollection .hasAttack(Area) inspection added.

### DIFF
--- a/src/net/codestrikes/sdk/ReadonlyMoveCollection.java
+++ b/src/net/codestrikes/sdk/ReadonlyMoveCollection.java
@@ -33,6 +33,10 @@ public class ReadonlyMoveCollection
         return moveList.stream().anyMatch(x -> x.getType() == MoveType.Defense && x.getArea() == area);
     }
 
+    public boolean hasAttack(Area area){
+        return moveList.stream().anyMatch(x -> x.getType() == MoveType.Attack && x.getArea() == area);
+    }
+
     public int sumEnergy(){
         return moveList.stream().mapToInt(x -> x.getEnergy()).sum();
     }


### PR DESCRIPTION
While there was an option for checking `Defense`s, no analogous `Attack` option was provided.

I've added it.